### PR TITLE
Add hero image to hugo.yml config

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -5,7 +5,6 @@ draft = false
 +++
 
 {{< section/hero
-image="images/Plains_wanderer_female.jpg"
 caption=" Image: JJ Harrison, CC BY-SA 3.0, via Wikimedia Commons">}}
 Can you hear a <br><span class="oe-theme-emphasis">Plains Wanderer</span>?
 {{< /section/hero >}}

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -27,6 +27,7 @@ menus:
 params:
   apiHost: https://api.staging.ecosounds.org
   workbenchHost: https://staging.ecosounds.org
+  heroImage: images/Plains_wanderer_female.jpg
   campaigns:
     - name: "Powerful Owl"
       filters:

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -6,3 +6,13 @@
 <script type="module" src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.20.0/cdn/shoelace.js" ></script>
 {{ partialCached "head/css.html" . }}
 {{ partialCached "head/js.html" . }}
+
+{{/*
+    Because the hero-image is likely to be a large image, we want to start
+    pre-fetching it as fast as possible so that it's visible as soon as the page
+    renders.
+*/}}
+{{ $heroImage := site.Params.HeroImage }}
+{{ with resources.Get $heroImage }}
+    <link rel="preload" as="image" href="{{ .RelPermalink }}">
+{{- end -}}

--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -14,7 +14,7 @@ Renders a menu for the given menu ID.
   <nav class="oe-navigation">
     <a href="/" class="oe-brand">{{ site.Title }}</a>
     {{- partial "inline/menu/walk.html" (dict "page" $page "menuEntries" .) }}
-    {{- partial "./auth-menu.html" }}
+    {{- partial "auth-menu.html" }}
     <sl-button href="/verify" variant="primary" pill>Validate Calls</sl-button>
   </nav>
 {{- end }}

--- a/layouts/shortcodes/section/hero.html
+++ b/layouts/shortcodes/section/hero.html
@@ -1,8 +1,10 @@
-<section class="oe-section oe-hero" {{ with .Get "image"  -}}
-{{- $image := resources.Get . -}}
-style="background-image: url('{{ $image.RelPermalink }}');"
-{{- end -}}
-{{- with .Get "class" -}}class="{{ . }}"{{- end -}}
+{{ $image := site.Params.HeroImage }}
+
+<section class="oe-section oe-hero"
+  {{ with resources.Get $image }}
+    style="background-image: url('{{ .RelPermalink }}');"
+  {{- end -}}
+  {{- with .Get "class" -}}class="{{ . }}"{{- end -}}
 >
   <div class="container">
         <h1 class="oe-hero-title">{{.Inner  | $.Page.RenderString }}</h1>


### PR DESCRIPTION
This lets us preload the hero image and reducer boilerplate in the homepage `_content.md`