### PR TITLE
feat: Add tag cache to fix duplicate tag requests

### DIFF
--- a/assets/js/workbenchApi.js
+++ b/assets/js/workbenchApi.js
@@ -209,8 +209,8 @@ export class WorkbenchApi {
         const tagRequest = async () => {
             const url = this.#createUrl(`/tags/${tagId}`);
             const response = await this.#fetch("GET", url);
-            const responseBody = response.body;
-            return responseBody;
+            const responseBody = await response.json();
+            return responseBody.data;
         };
 
         const tagPromise = tagRequest();
@@ -313,7 +313,7 @@ export class WorkbenchApi {
                 const tagOfInterest = taggings[0];
                 const tag = await this.getTag(tagOfInterest.tag_id);
 
-                model.tag = tag.data;
+                model.tag = tag;
             });
 
             await Promise.allSettled(associatedModelPromises);


### PR DESCRIPTION
# feat: Add tag cache to fix duplicate tag requests

When audio event models are returned from the api, we don't know the tag ids associated with the event without making a separate request to get the tag model.

This PR adds a tag cache that can index tag ids to a cached response model.

Promises are used for cached values so that if a tag request is made for a tag that has already been requested (but no response was received), we can await the same response promise and prevent sending duplicate requests.

## Limitations

This implementation assumes that the number of unique tags will be excessive because campaigns will typically be limited to a specific tag, or location, limiting the number of unique tags to a reasonable amount.

If this assumption is broken, we might see high memory usage due to a large number of unique tags.

A possible solution would be to use a "rotating queue" (don't know if that's the correct name), where each time a tag is requested, it goes to the front of the queue, and if the queue exceeds a certain limit (e.g. 100 items), the last item (the least requested tag cached) is removed.

I have not implemented this solution in the interest of time, and the fact that I don't believe there is a use case where a person will see hundreds of unique tags.

## Issues

Fixes: #34