### PR TITLE
fix: "undefined" tag id for verification upsert

### DIFF
--- a/assets/js/workbenchApi.js
+++ b/assets/js/workbenchApi.js
@@ -423,7 +423,7 @@ export class WorkbenchApi {
      */
     #verificationToBawModel(model) {
         const apiDecision = bawApiDecisionMapping[model.verification.confirmed];
-        const tagId = model.tag.tag_id;
+        const tagId = model.tag.id;
 
         const subject = model.subject;
         const apiModel = {


### PR DESCRIPTION
# fix: "undefined" tag id for verification upsert

When parsing out the tag id from the verification subject model, we incorrectly parsed out `tag.tag_id` instead of `tag.id`.

This resulted in upsert tag ids being sent as `undefined`.

## Issues

Fixes: #35