### PR TITLE
Fix login page redirects

### DIFF
--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -18,12 +18,20 @@ h6 {
     font-family: var(--oe-heading-font);
 }
 
-.oe-theme-emphasis {
-    color: var(--oe-theme-color);
+a {
+    color: var(--oe-font-color);
+
+    &:active {
+        color: var(--oe-font-color);
+    }
 }
 
-a.o-theme-emphasis {
-    text-decoration: none; /*links with theme emphasis no underline */
+.oe-theme-emphasis {
+    color: var(--oe-theme-color);
+
+    a {
+        text-decoration: none;
+    }
 }
 
 .container {

--- a/assets/js/bootstrapVerificationGrid.js
+++ b/assets/js/bootstrapVerificationGrid.js
@@ -72,7 +72,7 @@ async function setup() {
     const targetElements = gridElements();
     if (targetElements.length > 0) {
         if (!(await api.isLoggedIn())) {
-            window.location.href = "/login";
+            window.location.href = `/login?redirect=${location.pathname}`;
         }
     }
 

--- a/layouts/_default/login.html
+++ b/layouts/_default/login.html
@@ -98,12 +98,31 @@
         const formInputs = document.getElementsByClassName("login-form-input");
 
         function redirectSuccess() {
-            const hasHistory = window.history && window.history.length > 0;
-            if (hasHistory) {
-                window.history.back();
-            } else {
-                window.location.href = "/";
+            // We can navigate the user back to a previous page location using
+            // the "?redirect=/path" parameter.
+            const queryStrings = new URLSearchParams(location.search);
+            const redirectQsp = queryStrings.get("redirect");
+
+            // We don't use history.back here because the browsers bfcache
+            // would return a stale version of the webpage where the user is
+            // not logged in.
+            // https://web.dev/articles/bfcache
+            //
+            // We also use window.location.replace() instead of
+            // window.location.href so that if the user presses the back
+            // button, they will not be navigated back to the login page.
+            if (redirectQsp) {
+                // To minimize security risks, we don't allow the redirect parameter
+                // to point to an external site (or different sub-domain).
+                const redirectLocation = new URL(redirectQsp, location.host);
+                const isRedirectSafe = redirectLocation.hostname === location.hostname;
+
+                if (isRedirectSafe) {
+                    location.replace(redirectLocation);
+                }
             }
+
+            location.replace("/");
         }
 
         function printFailure(error) {


### PR DESCRIPTION
- The login page now navigates using `window.location.replace()` so that there's no bfcache
- The login page now uses a `redirect` query string parameter instead so that we don't navigate back to an empty page. If there is no redirect parameter, we redirect to the home page
- The login page now uses `window.location.replace` so that if the user presses the back button, they are not taken back to the login page

Fixes: #51
Fixes: #40