### PR TITLE
Use same themeing variables as web components

### DIFF
--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -4,7 +4,7 @@ body {
     min-height: 100dvh;
     display: flex;
     flex-direction: column;
-    font-family: var(--oe-body-font);
+    font-family: var(--oe-font-family);
     margin: 0;
     justify-content: space-between;
 }
@@ -39,7 +39,7 @@ a.o-theme-emphasis {
 /* Image captions */
 .oe-image-caption {
     color: var(--oe-font-color-toned);
-    font-size: var(--oe-font-size-xsmall);
+    font-size: var(--oe-font-size-small);
 }
 
 @media screen and (max-width: 500px) {

--- a/assets/css/footer.css
+++ b/assets/css/footer.css
@@ -1,19 +1,19 @@
 .oe-footer {
     background: var(--sl-color-primary-950);
     padding: var(--oe-padding-medium) 0px;
-    color: var(--oe-font-color-bright);
+    color: var(--oe-font-color-lighter);
     text-align: center;
     margin-top: var(--oe-padding-medium);
 
     .oe-footer-row {
         margin: var(--oe-padding-small);
-        font-size: var(--oe-font-size-xsmall);
+        font-size: var(--oe-font-size-small);
         display: flex;
         justify-content: center;
 
         a {
             text-decoration: none;
-            color: var(--oe-font-color-bright);
+            color: var(--oe-font-color-lighter);
 
             &:hover {
                 color: var(--oe-font-color-toned);

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -3,6 +3,7 @@
 @import "sections";
 @import "footer";
 @import "navigation";
+@import "theme";
 
 /* Added a second definition to separate templated values from not so syntax
   highlighting will work */
@@ -27,44 +28,4 @@
       var(--oe-theme-saturation),
       var(--oe-theme-lightness),
     );
-}
-
-:root {
-    /* Colors */
-    --oe-theme-color: var(--theme-color-raw);
-
-    /* Fonts */
-    --oe-heading-font: 'Inter', sans-serif;
-    --oe-body-font: 'Inter', sans-serif;
-    --oe-font-color: #000;
-    --oe-font-color-bright: #fff;
-    --oe-font-color-toned: #707070;
-    --oe-inverse-color: #000;
-
-    /* Backgrounds */
-    --oe-background-light: #fff;
-    --oe-background-dark: #000;
-    --oe-background-pane: #fcfcfc;
-
-    /* Font Sizes */
-    --oe-font-size-xsmall: 0.8rem;
-    --oe-font-size-small: 1rem;
-    --oe-font-size-medium: 1.5rem;
-    --oe-font-size-large: 2.25rem;
-    --oe-font-size-xlarge: 4.5rem;
-
-    /* Paddings */
-    --oe-padding-small: 0.5rem;
-    --oe-padding-medium: 1rem;
-    --oe-padding-large: 2rem;
-    --oe-padding-xlarge: 2.5rem;
-
-    /* Other */
-    --oe-navbar-height: 4rem;
-    --oe-panel-opacity: 0.8;
-    --oe-transition-duration: 0.3s;
-    --oe-transition-timing: ease-in-out;
-    --oe-box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    --oe-box-shadow-hover: 0 4px 8px rgba(0, 0, 0, 0.2);
-    --oe-border-radius: 0.25rem;
 }

--- a/assets/css/navigation.css
+++ b/assets/css/navigation.css
@@ -8,8 +8,7 @@
     z-index: 1;
 
     background-color: var(--oe-background-dark);
-    font-family: var(--oe-body-font);
-    font-size: var(--oe-font-size-small);
+    font-family: var(--oe-font-family);
 
     /*
         We set a gap here so that there is a minimum spacing between the left

--- a/assets/css/sections.css
+++ b/assets/css/sections.css
@@ -37,20 +37,20 @@ body section {
     color: white;
     text-shadow: 4px 2px 3px black;
 
-    font-size: var(--oe-font-size-xlarge);
+    font-size: 4.5rem;
     max-width: 30%;
     align-self: center;
 }
 
 .oe-hero-caption {
-    color: var(--oe-font-color-bright);
+    color: var(--oe-font-color-lighter);
     position: absolute;
     bottom: 0;
     right: 0;
     background-color: var(--oe-background-dark);
     opacity: 0.8;
     padding: var(--oe-padding-small);
-    font-size: var(--oe-font-size-xsmall);
+    font-size: var(--oe-font-size-small);
 }
 
 /*----- Call to Action  -----*/
@@ -97,7 +97,7 @@ body section {
 /*----- Smaller screen styles -----*/
 @media (max-width: 1024px) {
     .oe-hero-title {
-        font-size: var(--oe-font-size-large);
+        font-size: 2.25;
         max-width: 50%;
         padding: var(--oe-padding-small);
     }
@@ -108,7 +108,7 @@ body section {
         max-width: 95%;
     }
     .oe-call-to-action {
-        font-size: var(--oe-font-size-small);
+        font-size: var(--oe-font-size-medium);
     }
     .oe-image-column {
         flex-direction: column;

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -1,0 +1,44 @@
+@import url("https://fonts.googleapis.com/css2?family=Inter&display=swap");
+
+/*
+    We need the oe-verification-grid selector because of an upstream css
+    specificity bug with the web components.
+    see: https://github.com/ecoacoustics/web-components/issues/373
+
+    If you want to customize the base "theme color" use the hugo.yaml file's
+    params.style.ThemeColor
+*/
+:root, oe-verification-grid {
+    /* Fonts */
+    --oe-heading-font: 'Inter', sans-serif;
+    --oe-body-font: 'Inter', sans-serif;
+    --oe-font-color: #000;
+    --oe-font-color-bright: #fff;
+    --oe-font-color-toned: #707070;
+    --oe-inverse-color: #000;
+
+    /* Backgrounds */
+    --oe-background-light: #fff;
+    --oe-background-dark: #000;
+    --oe-background-pane: #fcfcfc;
+
+    /* Font Sizes */
+    --oe-font-size-small: 0.8rem;
+    --oe-font-size: 0.8rem;
+    --oe-font-size-medium: 1.5rem;
+
+    /* Paddings */
+    --oe-padding-small: 0.5rem;
+    --oe-padding-medium: 1rem;
+    --oe-padding-large: 2rem;
+    --oe-padding-xlarge: 2.5rem;
+
+    /* Other */
+    --oe-navbar-height: 4rem;
+    --oe-panel-opacity: 0.8;
+    --oe-transition-duration: 0.3s;
+    --oe-transition-timing: ease-in-out;
+    --oe-box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    --oe-box-shadow-hover: 0 4px 8px rgba(0, 0, 0, 0.2);
+    --oe-border-radius: 0.25rem;
+}

--- a/hugo.example.yaml
+++ b/hugo.example.yaml
@@ -24,11 +24,11 @@ params:
     # Theme colors are defined using "hsl" (hue, saturation, lightness).
     # To create your own hsl theme color, you can use the following website.
     # https://hslpicker.com/#ca7d2f
-    ThemeColor:
+    themeColor:
       hue: 30deg
       saturation: 62%
       lightness: 49%
-    ThemeShades:
+    themeShades:
       "50": 252 249 245
       "100": 247 234 222
       "200": 240 219 196

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -50,7 +50,7 @@ params:
     # Theme colors are defined using "hsl" (hue, saturation, lightness).
     # To create your own hsl theme color, you can use the following website.
     # https://hslpicker.com/#ca7d2f
-    ThemeColor:
+    themeColor:
       hue: 30deg
       saturation: 62%
       lightness: 49%
@@ -61,7 +61,7 @@ params:
     # In the interim, you can create theme colors using the shoelace color
     # token generator.
     # https://codepen.io/claviska/full/QWveRgL
-    ThemeShades:
+    themeShades:
       "50": 252 249 245
       "100": 247 234 222
       "200": 240 219 196

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,7 +3,7 @@
 <title>{{ if .IsHome }}{{ site.Title }}{{ else }}{{ printf "%s | %s" .Title site.Title }}{{ end }}</title>
 {{/* Shoelace */}}
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.20.0/cdn/themes/light.css" />
-<script type="module" src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.20.0/cdn/shoelace.js" ></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.20.0/cdn/shoelace.js"></script>
 {{ partialCached "head/css.html" . }}
 {{ partialCached "head/js.html" . }}
 


### PR DESCRIPTION
# [DRAFT] Use same themeing variables as web components

This PR changes the microsite's themeing variables to have the same name / meaning as the web component's theming variables.

This allows for seemless passthrough without translation.