### PR TITLE
Migrate to subgrid layout

### DIFF
--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -16,9 +16,12 @@ body {
         menu), it will tax the main content container for the space.
     */
     grid-template-columns:
-        [fullbleed-start] minmax(var(--micro-gutter-size), auto)
-        [main-start] calc(min(80rem, 90%))
-        [main-end] minmax(var(--micro-gutter-size), auto)
+        [fullbleed-start]
+        minmax(var(--micro-gutter-size), auto)
+        [main-start]
+        calc(min(80rem, 90%))
+        [main-end]
+        minmax(var(--micro-gutter-size), auto)
         [fullbleed-end]
     ;
 
@@ -28,9 +31,13 @@ body {
         content is larger.
     */
     grid-template-rows:
-      [header] minmax(4rem, auto)
-      [main] minmax(4rem, auto)
-      [footer] 4rem
+      [header]
+      minmax(4rem, auto)
+      [header-end main-start]
+      minmax(4rem, auto)
+      [main-end footer-start]
+      4rem
+      [footer-end]
     ;
 
     min-height: 100dvh;

--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -31,7 +31,7 @@ body {
         content is larger.
     */
     grid-template-rows:
-      [header]
+      [header-start]
       minmax(4rem, auto)
       [header-end main-start]
       minmax(4rem, auto)

--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -1,15 +1,86 @@
 body {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
+    display: grid;
+
+    /*
+        By using the [name-start] and [name-end] grid area syntax, we are able
+        to use a subgrid area by simply using the "name".
+
+        E.g. If you want an element to fullbleed (extend to the edges of the
+        page) you can simply do
+        grid-area: fullbleed
+
+        Note that page content defaults to centered content without fullbleed.
+        default: grid-area: main
+
+        ---
+
+        Additionally, note that the gutters have a minimum size of the inner
+        content meaning that if you add content to the gutters (e.g. a sidebar
+        menu), it will tax the main content container for the space.
+    */
+    grid-template-columns:
+        [fullbleed-start] minmax(var(--micro-gutter-size), auto)
+        [main-start] calc(min(80rem, 90%))
+        [main-end] minmax(var(--micro-gutter-size), auto)
+        [fullbleed-end]
+    ;
+
+    /*
+        By using the max between 4rem and auto, we can ensure that the header
+        and footer will be at least 4rem in height, but can expand if the
+        content is larger.
+    */
+    grid-template-rows:
+      [header] minmax(4rem, auto)
+      [main] minmax(4rem, auto)
+      [footer] 4rem
+    ;
 
     min-height: 100dvh;
-    margin: 0;
 
-    color: var(--micro-font-color);
+    /*
+        We set the background color on the body element because some browsers
+        such as mobile and Microsoft Edge support overscroll where the full page
+        content is moved.
+        When in an overscroll state, the background color will be used to fill.
+    */
     background-color: var(--micro-background-light);
 
+    color: var(--micro-font-color);
     font-family: var(--micro-body-font);
+
+    & > header {
+        grid-row: header;
+        grid-column: fullbleed;
+    }
+
+    & > main {
+        /*
+            We use contents here so that the body's subgrid is passed directly
+            to user-configurable
+        */
+        display: grid;
+        grid-template-columns: subgrid;
+
+        /* Restrict page content to using the column-subgrid */
+        grid-row: main;
+        grid-column: fullbleed;
+
+        .page > * {
+            /*
+                By default, we want the content to be centered and not to
+                fullbleed.
+                If you want your content to fullbleed, you can simply
+                use "grid-area: fullbleed"
+            */
+            grid-column: 2;
+        }
+    }
+
+    & > footer {
+        grid-row: footer;
+        grid-column: fullbleed;
+    }
 }
 
 section {
@@ -65,10 +136,9 @@ a {
     }
 }
 
-.container {
-    width: 100%;
-    max-width: calc(min(80rem, 90%));
-    margin: 0 auto;
+section {
+    padding-top: var(--micro-padding-large);
+    padding-bottom: var(--micro-padding-large);
 }
 
 figure {
@@ -104,10 +174,14 @@ figure {
     }
 }
 
-@media screen and (max-width: 500px) {
-    .container {
-        max-width: 100%;
-        padding-left: 0.75rem;
-        padding-right: 0.75rem;
-    }
+/*
+    You can use the .page helper class to create a scope for a certain page
+    while not effecting the page flow.
+*/
+.page {
+    display: contents;
+}
+
+.fullbleed {
+    grid-column: fullbleed !important;
 }

--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -9,9 +9,6 @@ body {
         page) you can simply do
         grid-area: fullbleed
 
-        Note that page content defaults to centered content without fullbleed.
-        default: grid-area: main
-
         ---
 
         Additionally, note that the gutters have a minimum size of the inner
@@ -42,7 +39,9 @@ body {
         We set the background color on the body element because some browsers
         such as mobile and Microsoft Edge support overscroll where the full page
         content is moved.
-        When in an overscroll state, the background color will be used to fill.
+        When in an overscroll state, the bodys background color will be used to
+        fill. If we did not set the background color here, the overscroll would
+        default to a white/black (depending on color scheme) color.
     */
     background-color: var(--micro-background-light);
 
@@ -56,24 +55,23 @@ body {
 
     & > main {
         /*
-            We use contents here so that the body's subgrid is passed directly
-            to user-configurable
+            Restrict page content to using the column-subgrid so that consumers
+            of this theme cannot create out-of-order positioned elements by
+            assigning a content to the a "header" subgrid row.
         */
         display: grid;
         grid-template-columns: subgrid;
 
-        /* Restrict page content to using the column-subgrid */
         grid-row: main;
         grid-column: fullbleed;
 
         .page > * {
             /*
-                By default, we want the content to be centered and not to
-                fullbleed.
-                If you want your content to fullbleed, you can simply
-                use "grid-area: fullbleed"
+                By default, we want the content to be centered.
+                If you want your content to extend to the edge of the page,
+                you can simply use the "fullbleed" class.
             */
-            grid-column: 2;
+            grid-column: main;
         }
     }
 
@@ -84,6 +82,9 @@ body {
 }
 
 section {
+    padding-top: var(--micro-padding-large);
+    padding-bottom: var(--micro-padding-large);
+
     margin-bottom: var(--micro-padding-xlarge);
 }
 
@@ -134,11 +135,6 @@ a {
     &:active {
         color: var(--micro-font-color);
     }
-}
-
-section {
-    padding-top: var(--micro-padding-large);
-    padding-bottom: var(--micro-padding-large);
 }
 
 figure {

--- a/assets/css/footer.css
+++ b/assets/css/footer.css
@@ -3,7 +3,6 @@
     padding: var(--micro-padding-medium) 0px;
     color: var(--micro-font-color-light);
     text-align: center;
-    margin-top: var(--micro-padding-medium);
 
     .oe-footer-row {
         margin: var(--micro-padding-small);

--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -1,32 +1,15 @@
-body:has(#home-page) {
-    /*
-        This hack was done because the hero image overflows on Chrome.
-
-        TODO: Remove this once we migrate to a subgrid layout
-        https://development.ecosounds.org:1313/
-    */
-    overflow-x: hidden;
-}
-
 #home-page {
-    /*----- Sections -----*/
-    section {
-        padding-top: var(--micro-padding-large);
-        padding-bottom: var(--micro-padding-large);
-    }
-
     /*----- Hero -----*/
     .oe-hero {
         display: flex;
         align-items: center;
+        justify-content: space-evenly;
 
+        /*
+            We need position: relative so that the image caption and citation is
+            positioned relative to the hero container.
+        */
         position: relative;
-        width: 100lvw;
-        height: auto;
-        top: 0;
-        left: 50%;
-        right: 50%;
-        transform: translateX(-50%);
 
         background-size: cover;
         background-repeat: no-repeat;
@@ -145,7 +128,14 @@ body:has(#home-page) {
     }
 
     /*----- Smaller screen styles -----*/
-    @media (max-width: 1024px) {
+    /*
+        We use rem units for media queries so that if the user changes the font
+        size in the browser settings, the site will automatically adjust.
+
+        Note that most browsers default to a font size of 16px.
+        Therefore, the calculation is 16 * rem to find the default pixel value.
+    */
+    @media (max-width: 64rem /* 1024px */) {
         .hero-content {
             gap: 0%;
         }
@@ -156,7 +146,7 @@ body:has(#home-page) {
         }
     }
 
-    @media (max-width: 768px) {
+    @media (max-width: 48rem /* 768px */) {
         .hero-content {
             gap: 10%;
         }
@@ -174,14 +164,9 @@ body:has(#home-page) {
         }
     }
 
-    @media (max-width: 425px) {
+    @media (max-width: 31.25rem /* 420px */) {
         .oe-hero-title {
             font-size: var(--micro-font-size-medium);
         }
-
-        .oe-hero .container {
-            height: auto;
-        }
-
     }
 }

--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -135,7 +135,7 @@
         Note that most browsers default to a font size of 16px.
         Therefore, the calculation is 16 * rem to find the default pixel value.
     */
-    @media (max-width: 64rem /* 1024px */) {
+    @media (max-width: 64em /* 1024px */) {
         .hero-content {
             gap: 0%;
         }
@@ -146,7 +146,7 @@
         }
     }
 
-    @media (max-width: 48rem /* 768px */) {
+    @media (max-width: 48em /* 768px */) {
         .hero-content {
             gap: 10%;
         }
@@ -164,7 +164,7 @@
         }
     }
 
-    @media (max-width: 31.25rem /* 420px */) {
+    @media (max-width: 31.25em /* 420px */) {
         .oe-hero-title {
             font-size: var(--micro-font-size-medium);
         }

--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -3,7 +3,6 @@
     .oe-hero {
         display: flex;
         align-items: center;
-        justify-content: space-evenly;
 
         /*
             We need position: relative so that the image caption and citation is

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -35,6 +35,13 @@
     --micro-padding-large: 2rem;
     --micro-padding-xlarge: 2.5rem;
 
+    /*
+        The minimum amount of space either side of the main (non-fullbleed)
+        content.
+        This is the amount of padding around the main content on mobile.
+    */
+    --micro-gutter-size: 0.75rem;
+
     /* Other */
     --micro-navbar-height: 4rem;
     --micro-panel-opacity: 0.8;

--- a/content/_index.md
+++ b/content/_index.md
@@ -62,7 +62,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 
 {{< /section/image-column >}}
 
-<div class="progress-container">
+<section class="progress-container">
     {{< section/project-progress >}}
     {{< /section/project-progress >}}
     <div>
@@ -80,4 +80,4 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
             </li>
         </ul>
     </div>
-</div>
+</section>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -5,7 +5,7 @@
 </head>
 <body>
   {{ partial "header.html" . }}
-  <main class="container">
+  <main>
     {{ block "main" . }}{{ end }}
   </main>
   <footer>

--- a/layouts/_default/home.html
+++ b/layouts/_default/home.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-<div id="home-page" class="oe-home">
+<div id="home-page" class="page">
   {{ .Content }}
 </div>
 {{ end }}

--- a/layouts/_default/login.html
+++ b/layouts/_default/login.html
@@ -1,4 +1,5 @@
 {{ define "main" }}
+<div id="login-page" class="page">
     <div class="login-container">
         <sl-card class="card-header">
             <div slot="header"><h1>{{ .Title }}</h1></div>
@@ -199,4 +200,5 @@
 
         setupLogin();
     </script>
+</div>
 {{ end }}

--- a/layouts/_default/verify.html
+++ b/layouts/_default/verify.html
@@ -1,4 +1,5 @@
 {{ define "main" }}
+<div id="verify-page" class="page">
     {{ .Content }}
 
     <style>
@@ -42,4 +43,5 @@
         {{- end }}
     {{- end }}
     {{- end }}
+</div>
 {{ end }}

--- a/layouts/shortcodes/fullbleed.html
+++ b/layouts/shortcodes/fullbleed.html
@@ -1,0 +1,19 @@
+{{/*
+Creates a section that will expand to the full page width.
+
+@context {class} Classes to add to this fullbleed section.
+
+@example:
+    {{< fullbleed >}}
+        <img src="full-width-image.png">
+    {{< /fullbleed >}}
+*/}}
+
+{{/*
+    We do not use a section element here because sections have implicit padding
+    added by the common stylesheet, and this shortcode is intended to only be
+    used in layout positioning.
+*/}}
+<div class='fullbleed {{ .Get "class" }}'>
+    {{ .Inner }}
+</div>

--- a/layouts/shortcodes/section/hero.html
+++ b/layouts/shortcodes/section/hero.html
@@ -1,6 +1,6 @@
 {{ $image := site.Params.HeroImage }}
 
-<section class="oe-hero"
+<section class="oe-hero fullbleed"
   {{ with resources.Get $image }}
     style="background-image: url('{{ .RelPermalink }}');"
   {{- end -}}

--- a/layouts/shortcodes/section/project-progress.html
+++ b/layouts/shortcodes/section/project-progress.html
@@ -105,7 +105,7 @@
 
     function updateCard(unverified, verified) {
         const totalCount = verified + unverified;
-        const textMessage = `${verified} of ${unverified} audio clips reviewed`;
+        const textMessage = `${verified} of ${totalCount} audio clips reviewed`;
 
         // I floor the number so that when we approach 100% verification, users
         // don't see a 100% verified state and stop verifying.

--- a/microsite.code-workspace
+++ b/microsite.code-workspace
@@ -52,7 +52,8 @@
             "microsite",
             "taggings",
             "ecosounds",
-            "ecoacoustics"
+            "ecoacoustics",
+            "fullbleed"
         ]
     },
     "extensions": {


### PR DESCRIPTION
## Layout & Positioning

- Migrates to a subgrid layout
- Adds `{{< fullbleed >}}` shortcode to create content that spans the entire page width
- Adds new configurable `--micro-gutter-size` css variable
- Removes `container` helper
- **Correctly** fixes hero image overflow (in the interest of time, I previously just disabled `x-overflow`)
- Add `.page` helper class that can be used to scope styles without effecting flow

## Bug Fixes

- Fixes project progress count incorrectly using unverified count for "total count" text

## Misc

- Migrates to `em` units for media queries instead of `px`. This adds support for correct scaling when changing the browsers default font size, or using Firefox's "zoom text only" option. (see why I'm using `em` instead of `rem` https://medium.com/@barrypeng6/why-should-not-use-rem-unit-in-media-query-5645d0163ce5)

## Issues

Fixes: https://github.com/ecoacoustics/microsite-template/issues/50