### PR TITLE
Fix register link in login layout

### DIFF
--- a/layouts/_default/login.html
+++ b/layouts/_default/login.html
@@ -40,7 +40,7 @@
 
             {{ .Content }}
             <p>Don't have an account?
-                <a href="{{ site.Params.workbenchhost }}/register">Register here</a>.
+                <a href="{{ site.Params.workbenchhost }}/security/register">Register here</a>.
             </p>
         </sl-card>
     </div>


### PR DESCRIPTION
Register link was pointing to `ecosounds.org/register` instead of the correct `ecosounds.org/security/register`

Fixes: #82