### PR TITLE
fix: Padding for N*M verification grid

### DIFF
--- a/layouts/_default/verify.html
+++ b/layouts/_default/verify.html
@@ -3,6 +3,11 @@
     {{ .Content }}
 
     <style>
+        oe-verification-grid {
+            display: block;
+            padding: var(--micro-padding-small);
+        }
+
         /*
             TODO: remove this once upstream max tile sizes have been implemented
             see: https://github.com/ecoacoustics/web-components/issues/391
@@ -21,11 +26,6 @@
             max-height: 50rem;
 
             margin: auto;
-        }
-
-        oe-verification-grid {
-            display: block;
-            padding: var(--micro-padding-small);
         }
     </style>
 

--- a/layouts/_default/verify.html
+++ b/layouts/_default/verify.html
@@ -8,8 +8,6 @@
             see: https://github.com/ecoacoustics/web-components/issues/391
         */
         oe-verification-grid[grid-size="1"] {
-            display: block;
-            
             /*
                 50rem is 800px on a default browser with font size 16.
                 We use rem units instead of px so that if the user zooms in, or
@@ -21,8 +19,13 @@
             */
             max-width: 50rem;
             max-height: 50rem;
-            padding: var(--micro-padding-small);
+
             margin: auto;
+        }
+
+        oe-verification-grid {
+            display: block;
+            padding: var(--micro-padding-small);
         }
     </style>
 


### PR DESCRIPTION
I was conditionally applying padding depending on the grid size.

This commit changes the padding styling to always apply regardless of grid size.