### PR TITLE
Add `event-card` shortcode

### DIFF
--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -190,7 +190,7 @@ figure {
         If we did not have this condition, there would always be a box the size
         of the padding.
     */
-    &:has(::content) {
+    &:not(:empty) {
         padding: var(--micro-padding-small);
     }
 }

--- a/assets/css/navigation.css
+++ b/assets/css/navigation.css
@@ -14,11 +14,12 @@ header {
 
     position: relative;
     top: 0;
+    min-height: 72px;
 
-    background-color: var(--micro-background-light);
+    background-color: var(--micro-nav-background-color);
     font-family: var(--micro-body-font);
     font-size: var(--micro-font-size-small);
-    color: var(--micro-font-color-light);
+    color: var(--micro-nav-font-color);
 
     /*
         We set a gap here so that there is a minimum spacing between the left
@@ -44,7 +45,7 @@ header {
     }
 
     a {
-        color: var(--micro-font-color-light);
+        color: var(--micro-nav-font-color);
         text-decoration: none;
     }
 }

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -16,8 +16,11 @@
     --micro-inverse-color: #000;
     --micro-heading-color: #000;
 
+    --micro-nav-background-color: var(--micro-background-light);
+    --micro-nav-font-color: var(--micro-font-color);
+
     --micro-footer-background-color: var(--sl-color-primary-950);
-    --micro-footer-text-color: var(--micro-font-color-light);
+    --micro-footer-font-color: var(--micro-font-color-light);
 
     /* Backgrounds */
     --micro-background-light: #fff;

--- a/assets/js/annotations.js
+++ b/assets/js/annotations.js
@@ -1,0 +1,33 @@
+// TODO: Refactor this function once we support object annotations
+// see: https://github.com/ecoacoustics/web-components/issues/501
+export function createAnnotation(
+    annotationTarget,
+    audioEvent,
+    label,
+    contextPaddingStart,
+) {
+    const eventDuration =
+        audioEvent.end_time_seconds - audioEvent.start_time_seconds;
+
+    // Because annotations do not obey the spectrogram offset, we have to set
+    // the start-time relative to the start of the spectrogram.
+    //
+    // TODO: Once the oe-annotate component supports spectrogram offsets,
+    // we can remove the contextPaddingStart parameter and just use the
+    // audioEvent.start_time_seconds directly.
+    // see: https://github.com/ecoacoustics/web-components/issues/505
+    const attributeMap = new Map([
+        ["start-time", contextPaddingStart],
+        ["end-time", eventDuration + contextPaddingStart],
+        ["low-frequency", audioEvent.low_frequency_hertz],
+        ["high-frequency", audioEvent.high_frequency_hertz],
+        ["tags", label],
+    ]);
+
+    const annotationElement = document.createElement("oe-annotation");
+    for (const [key, value] of attributeMap) {
+        annotationElement.setAttribute(key, value);
+    }
+
+    annotationTarget.appendChild(annotationElement);
+}

--- a/assets/js/annotations.js
+++ b/assets/js/annotations.js
@@ -1,33 +1,33 @@
 // TODO: Refactor this function once we support object annotations
 // see: https://github.com/ecoacoustics/web-components/issues/501
 export function createAnnotation(
-    annotationTarget,
-    audioEvent,
-    label,
-    contextPaddingStart,
+  annotationTarget,
+  audioEvent,
+  label,
+  contextPaddingStart,
 ) {
-    const eventDuration =
-        audioEvent.end_time_seconds - audioEvent.start_time_seconds;
+  const eventDuration =
+    audioEvent.end_time_seconds - audioEvent.start_time_seconds;
 
-    // Because annotations do not obey the spectrogram offset, we have to set
-    // the start-time relative to the start of the spectrogram.
-    //
-    // TODO: Once the oe-annotate component supports spectrogram offsets,
-    // we can remove the contextPaddingStart parameter and just use the
-    // audioEvent.start_time_seconds directly.
-    // see: https://github.com/ecoacoustics/web-components/issues/505
-    const attributeMap = new Map([
-        ["start-time", contextPaddingStart],
-        ["end-time", eventDuration + contextPaddingStart],
-        ["low-frequency", audioEvent.low_frequency_hertz],
-        ["high-frequency", audioEvent.high_frequency_hertz],
-        ["tags", label],
-    ]);
+  // Because annotations do not obey the spectrogram offset, we have to set
+  // the start-time relative to the start of the spectrogram.
+  //
+  // TODO: Once the oe-annotate component supports spectrogram offsets,
+  // we can remove the contextPaddingStart parameter and just use the
+  // audioEvent.start_time_seconds directly.
+  // see: https://github.com/ecoacoustics/web-components/issues/505
+  const attributeMap = new Map([
+    ["start-time", contextPaddingStart],
+    ["end-time", eventDuration + contextPaddingStart],
+    ["low-frequency", audioEvent.low_frequency_hertz],
+    ["high-frequency", audioEvent.high_frequency_hertz],
+    ["tags", label],
+  ]);
 
-    const annotationElement = document.createElement("oe-annotation");
-    for (const [key, value] of attributeMap) {
-        annotationElement.setAttribute(key, value);
-    }
+  const annotationElement = document.createElement("oe-annotation");
+  for (const [key, value] of attributeMap) {
+    annotationElement.setAttribute(key, value);
+  }
 
-    annotationTarget.appendChild(annotationElement);
+  annotationTarget.appendChild(annotationElement);
 }

--- a/assets/js/bootstrapVerificationGrid.js
+++ b/assets/js/bootstrapVerificationGrid.js
@@ -18,17 +18,26 @@ async function bootstrapVerificationGrid(target, filterBody) {
 
   target.addEventListener("decision-made", (event) => {
     const decisions = event.detail;
-    for (const decision of decisions) {
-      // Each call to "upsertVerification" is an async fire and forget
-      // call to the api.
-      // Each request is an un-awaited async method call so that it
-      // doesn't lock up the main thread and freeze the website when an
-      // api call is made.
-      //
-      // If an upsert request errors or fails to be applied, there is no
-      // retry logic, and the verification will fail to commit to the
-      // database.
-      api.upsertVerification(decision);
+    for (const [subject, receipt] of decisions) {
+      const change = receipt.change;
+      const verificationChange = change.verification;
+
+      // If the verification change is null, it indicates that the user has
+      // deleted a previously applied verification.
+      if (verificationChange === null) {
+        api.deleteVerification(subject);
+      } else {
+        // Each call to "upsertVerification" is an async fire and forget
+        // call to the api.
+        // Each request is an un-awaited async method call so that it
+        // doesn't lock up the main thread and freeze the website when an
+        // api call is made.
+        //
+        // If an upsert request errors or fails to be applied, there is no
+        // retry logic, and the verification will fail to commit to the
+        // database.
+        api.upsertVerification(subject);
+      }
     }
   });
 }

--- a/assets/js/workbenchApi.js
+++ b/assets/js/workbenchApi.js
@@ -230,7 +230,8 @@ export class WorkbenchApi {
     }
 
     /**
-     * Fetches an audio event from the API using an audio event id.
+     * Fetches an audio event from the API using an audio recording and audio
+     * event id.
      *
      * @param {number} audioRecordingId
      * @param {number} audioEventId 
@@ -238,6 +239,21 @@ export class WorkbenchApi {
      */
     async getAudioEvent(audioRecordingId, audioEventId) {
         const url = this.#createUrl(`/audio_recordings/${audioRecordingId}/audio_events/${audioEventId}`);
+
+        const response = await this.#fetch("GET", url);
+        const responseBody = await response.json();
+
+        return responseBody.data;
+    }
+
+    /**
+     * Fetches an audio recording model from the API using an audio recording id
+     *
+     * @param {number} audioRecordingId
+     * @returns {Promise<AudioEvent>}
+     */
+    async getAudioRecording(audioRecordingId) {
+        const url = this.#createUrl(`/audio_recordings/${audioRecordingId}`);
 
         const response = await this.#fetch("GET", url);
         const responseBody = await response.json();
@@ -506,7 +522,8 @@ export class WorkbenchApi {
 
         // We use a URL object so that if the url already has query parameter,
         // it will be added using a "&" instead of a "?".
-        // It also handles encoding the query parameter correctly.
+        // Using a URL object also automatically handles encoding the query
+        // parameter.
         //
         // Note: This will throw an error if the url is not valid.
         const urlObj = new URL(url);

--- a/assets/js/workbenchApi.js
+++ b/assets/js/workbenchApi.js
@@ -13,7 +13,8 @@ const bawApiDecisionMapping = {
 /**
  * A callback that can be used to get the current global WorkbenchApi instance
  */
-globalThis.workbenchApi ??= () => WorkbenchApi.instance(globalThis.siteParams.apihost);
+globalThis.workbenchApi ??= () =>
+    WorkbenchApi.instance(globalThis.siteParams.apihost);
 
 /**
  * A service to interact with the baw-api
@@ -234,11 +235,13 @@ export class WorkbenchApi {
      * event id.
      *
      * @param {number} audioRecordingId
-     * @param {number} audioEventId 
+     * @param {number} audioEventId
      * @returns {Promise<AudioEvent>}
      */
     async getAudioEvent(audioRecordingId, audioEventId) {
-        const url = this.#createUrl(`/audio_recordings/${audioRecordingId}/audio_events/${audioEventId}`);
+        const url = this.#createUrl(
+            `/audio_recordings/${audioRecordingId}/audio_events/${audioEventId}`,
+        );
 
         const response = await this.#fetch("GET", url);
         const responseBody = await response.json();
@@ -512,7 +515,7 @@ export class WorkbenchApi {
     /**
      * Adds a user authentication token to a url as a query parameter.
      *
-     * @param {string} url 
+     * @param {string} url
      * @returns {string}
      */
     #withUserToken(url) {

--- a/assets/js/workbenchApi.js
+++ b/assets/js/workbenchApi.js
@@ -310,8 +310,8 @@ export class WorkbenchApi {
      * Deletes a verification object from the server using the audio event id
      * (subject id) + tag id as a unique identifier.
      *
-     * @param {SubjectWrapper} model - The verification object to create
-     * @returns {Promise<boolean>} - A boolean value indicating whether the verification was created successfully
+     * @param {SubjectWrapper} model - The verification object to delete
+     * @returns {Promise<boolean>} - A boolean value indicating whether the verification was deleted successfully
      */
     async deleteVerification(model) {
         const audioEventId = model.subject.id;

--- a/assets/js/workbenchApi.js
+++ b/assets/js/workbenchApi.js
@@ -250,7 +250,7 @@ export class WorkbenchApi {
      * Fetches an audio recording model from the API using an audio recording id
      *
      * @param {number} audioRecordingId
-     * @returns {Promise<AudioEvent>}
+     * @returns {Promise<AudioRecording>}
      */
     async getAudioRecording(audioRecordingId) {
         const url = this.#createUrl(`/audio_recordings/${audioRecordingId}`);

--- a/content/_index.md
+++ b/content/_index.md
@@ -13,11 +13,6 @@ caption="Image: JJ Harrison, CC BY-SA 3.0, via Wikimedia Commons"
 title="Can you hear a Plains Wanderer?">}}
 {{< /section/hero >}}
 
-{{< event-card
-audioEventUrl="https://api.staging.ecosounds.org/audio_recordings/704106/media.flac?start_offset=567&end_offset=570"
->}}
-{{< /event-card >}}
-
 {{< section/call-to-action >}}
 The Plains Wanderer is critically endangered due to habitat loss, predation, and climate change. We're on a mission to train our AI to recognise their calls, and we need your help! By checking the tags our system has put on bird calls, you can help ensure they're correct. This helps us monitor their populations and habitats more effectively, contributing to conservation efforts.
 <a href="/verify">Sign up or log in</a> to start verifying calls.

--- a/content/_index.md
+++ b/content/_index.md
@@ -3,10 +3,20 @@ title = "Home"
 date = 2023-01-01T08:00:00-07:00
 +++
 
+<script
+    type="module"
+    src="https://cdn.jsdelivr.net/npm/@ecoacoustics/web-components/dist/components.js"
+></script>
+
 {{< section/hero
 caption="Image: JJ Harrison, CC BY-SA 3.0, via Wikimedia Commons"
 title="Can you hear a Plains Wanderer?">}}
 {{< /section/hero >}}
+
+{{< event-card
+audioEventUrl="https://api.staging.ecosounds.org/audio_recordings/704106/media.flac?start_offset=567&end_offset=570"
+>}}
+{{< /event-card >}}
 
 {{< section/call-to-action >}}
 The Plains Wanderer is critically endangered due to habitat loss, predation, and climate change. We're on a mission to train our AI to recognise their calls, and we need your help! By checking the tags our system has put on bird calls, you can help ensure they're correct. This helps us monitor their populations and habitats more effectively, contributing to conservation efforts.

--- a/content/_index.md
+++ b/content/_index.md
@@ -3,11 +3,6 @@ title = "Home"
 date = 2023-01-01T08:00:00-07:00
 +++
 
-<script
-    type="module"
-    src="https://cdn.jsdelivr.net/npm/@ecoacoustics/web-components/dist/components.js"
-></script>
-
 {{< section/hero
 caption="Image: JJ Harrison, CC BY-SA 3.0, via Wikimedia Commons"
 title="Can you hear a Plains Wanderer?">}}

--- a/content/verify/_index.md
+++ b/content/verify/_index.md
@@ -18,22 +18,29 @@ title = "Can you hear a Plains Wanderer?"
     ></oe-data-source>
 </oe-verification-grid>
 
-<div class="example-calls">
-    {{< event-card audioRecordingId="352803" audioEventId="269965" label="Plains Wander (female)" >}}
-    {{< /event-card >}}
-    {{< event-card audioRecordingId="352803" audioEventId="269937" label="Plains Wander (male)" >}}
-    {{< /event-card >}}
+<div class="examples-container">
+    <h3>Example Calls</h3>
+    <div class="example-calls">
+        {{< event-card audioRecordingId="352803" audioEventId="269965" label="Plains Wanderer (female)" >}}
+        {{< /event-card >}}
+        {{< event-card audioRecordingId="352803" audioEventId="269937" label="Plains Wanderer (male)" >}}
+        {{< /event-card >}}
+    </div>
 </div>
 
 <style>
+.examples-container {
+    margin-block: var(--micro-padding-large);
+}
+
 .example-calls {
     display: flex;
     gap: var(--micro-padding-medium);
-
-    margin-top: var(--micro-padding-large);
+    flex-wrap: wrap;
 
     > * {
         flex: 1 1;
+        min-width: 20rem;
     }
 }
 </style>

--- a/content/verify/_index.md
+++ b/content/verify/_index.md
@@ -18,8 +18,22 @@ title = "Can you hear a Plains Wanderer?"
     ></oe-data-source>
 </oe-verification-grid>
 
-{{< event-card audioRecordingId="352803" audioEventId="269965" label="Plains Wander (female)" >}}
-{{< /event-card >}}
+<div class="example-calls">
+    {{< event-card audioRecordingId="352803" audioEventId="269965" label="Plains Wander (female)" >}}
+    {{< /event-card >}}
+    {{< event-card audioRecordingId="352803" audioEventId="269937" label="Plains Wander (male)" >}}
+    {{< /event-card >}}
+</div>
 
-{{< event-card audioRecordingId="352803" audioEventId="269937" label="Plains Wander (male)" >}}
-{{< /event-card >}}
+<style>
+.example-calls {
+    display: flex;
+    gap: var(--micro-padding-medium);
+
+    margin-top: var(--micro-padding-large);
+
+    > * {
+        flex: 1 1;
+    }
+}
+</style>

--- a/content/verify/_index.md
+++ b/content/verify/_index.md
@@ -10,6 +10,7 @@ title = "Can you hear a Plains Wanderer?"
 <oe-verification-grid data-campaign="Powerful Owl" id="verification-grid" grid-size="1">
     <oe-verification verified="true" shortcut="y">Yes</oe-verification>
     <oe-verification verified="false" shortcut="n">No</oe-verification>
+    <oe-verification verified="unsure" shortcut="u">Unsure</oe-verification>
     <oe-data-source
         slot="data-source"
         for="verification-grid"

--- a/content/verify/_index.md
+++ b/content/verify/_index.md
@@ -2,11 +2,6 @@
 title = "Can you hear a Plains Wanderer?"
 +++
 
-<script
-    type="module"
-    src="https://cdn.jsdelivr.net/npm/@ecoacoustics/web-components/dist/components.js"
-></script>
-
 <oe-verification-grid data-campaign="Powerful Owl" id="verification-grid" grid-size="1">
     <oe-verification verified="true" shortcut="y">Yes</oe-verification>
     <oe-verification verified="false" shortcut="n">No</oe-verification>

--- a/content/verify/_index.md
+++ b/content/verify/_index.md
@@ -17,3 +17,9 @@ title = "Can you hear a Plains Wanderer?"
         allow-downloads="false"
     ></oe-data-source>
 </oe-verification-grid>
+
+{{< event-card audioRecordingId="352803" audioEventId="269965" label="Plains Wander (female)" >}}
+{{< /event-card >}}
+
+{{< event-card audioRecordingId="352803" audioEventId="269937" label="Plains Wander (male)" >}}
+{{< /event-card >}}

--- a/layouts/_default/verify.html
+++ b/layouts/_default/verify.html
@@ -21,7 +21,7 @@
             */
             width: 100%;
             max-width: 56rem;
-            max-height: 50rem;
+            max-height: 56rem;
             padding: var(--micro-padding-small);
             margin: auto;
         }

--- a/layouts/_default/verify.html
+++ b/layouts/_default/verify.html
@@ -29,7 +29,7 @@
 
     <script
         type="module"
-        src="https://cdn.jsdelivr.net/npm/@ecoacoustics/web-components@3/dist/components.js"
+        src="https://cdn.jsdelivr.net/npm/@ecoacoustics/web-components@5/dist/components.js"
     ></script>
 
     {{- with resources.Get "js/bootstrapVerificationGrid.js" }}

--- a/layouts/_default/verify.html
+++ b/layouts/_default/verify.html
@@ -11,15 +11,16 @@
             display: block;
             
             /*
-                50rem is 800px on a default browser with font size 16.
+                56rem is 896px on a default browser with font size 16.
                 We use rem units instead of px so that if the user zooms in, or
                 is on a high dpi screen, the verification grid can fill up a
                 relatively larger portion of the screen.
 
-                I have also chosen 800px for the maximum size because it is
+                I have also chosen 896px for the maximum size because it is
                 close to the minimum size before the controls start wrapping.
             */
-            max-width: 50rem;
+            width: 100%;
+            max-width: 56rem;
             max-height: 50rem;
             padding: var(--micro-padding-small);
             margin: auto;

--- a/layouts/shortcodes/event-card.html
+++ b/layouts/shortcodes/event-card.html
@@ -37,23 +37,12 @@
 </div>
 
 <script type="module">
+    {{- with resources.Get "js/annotations.js" }}
+        import { createAnnotation } from "{{ .RelPermalink }}";
+    {{- end }}
+
     const spectrogramTarget = document.getElementById("{{ $id }}-spectrogram");
     const annotationTarget = document.getElementById("{{ $id }}-annotations");
-
-    // TODO: Refactor this function once we support object annotations
-    // see: https://github.com/ecoacoustics/web-components/issues/501
-    function createAnnotation(audioEvent, label, contextPaddingStart) {
-        const eventDuration = audioEvent.end_time_seconds - audioEvent.start_time_seconds;
-
-        const annotationElement = document.createElement("oe-annotation");
-        annotationElement.setAttribute("start-time", contextPaddingStart);
-        annotationElement.setAttribute("end-time", eventDuration + contextPaddingStart);
-        annotationElement.setAttribute("low-frequency", audioEvent.low_frequency_hertz);
-        annotationElement.setAttribute("high-frequency", audioEvent.high_frequency_hertz);
-        annotationElement.setAttribute("tags", label);
-
-        annotationTarget.appendChild(annotationElement);
-    }
 
     const api = await workbenchApi();
 
@@ -83,9 +72,15 @@
     //
     // Additionally, we clamp to the start and end of the recording so that we
     // don't try to fetch audio that is outside the bounds of the recording.
-    const contextPadding = Math.min(2, eventDuration / 4);
-    const contextStartTime = Math.max(audioEvent.start_time_seconds - contextPadding, 0);
-    const contextEndTime = Math.min(audioEvent.end_time_seconds + contextPadding, audioRecordingDuration);
+    const minimumEventDurationSeconds = 4;
+    const defaultPaddingSeconds = 1;
+
+    const contextPaddingSeconds = eventDuration < minimumEventDurationSeconds
+        ? eventDuration / 2
+        : defaultPaddingSeconds;
+
+    const contextStartTime = Math.max(audioEvent.start_time_seconds - contextPaddingSeconds, 0);
+    const contextEndTime = Math.min(audioEvent.end_time_seconds + contextPaddingSeconds, audioRecordingDuration);
 
     // How much padding we added to the start of the event. Because this can be
     // clamped to the start of the recording, we need to calculate this after
@@ -104,7 +99,7 @@
     // from the start of the spectrogram the event starts at.
     // We cannot use the contextPadding in case the context start time was
     // clamped to the start of the recording.
-    createAnnotation(audioEvent, label, contextPaddingStart);
+    createAnnotation(annotationTarget, audioEvent, label, contextPaddingStart);
 </script>
 
 <style>

--- a/layouts/shortcodes/event-card.html
+++ b/layouts/shortcodes/event-card.html
@@ -1,0 +1,31 @@
+{{ $id := printf "spectrogram-card-%03d" $.Ordinal }}
+
+{{ $audio_event_url := .Get "audioEventUrl" }}
+
+<div>
+    <sl-card class="spectrogram-card">
+        <h3 class="card-heading">{{ .Get "title" }}</h3>
+        <p class="progress-text">{{ .Get "description" }}</p>
+
+        <oe-annotate>
+            <oe-indicator>
+                <oe-spectrogram id="{{ $id }}"></oe-spectrogram>
+            </oe-indicator>
+        </oe-annotate>
+        <oe-media-controls for="{{ $id }}"></oe-media-controls>
+
+        {{ .Inner }}
+    </sl-card>
+</div>
+
+<script type="module">
+    const spectrogramElement = document.getElementById("{{ $id }}");
+
+    const audioEventUrl = "{{ $audio_event_url }}";
+</script>
+
+<style>
+    .spectrogram-card {
+        display: block;
+    }
+</style>

--- a/layouts/shortcodes/event-card.html
+++ b/layouts/shortcodes/event-card.html
@@ -121,8 +121,8 @@
         .event-label {
             margin: 0;
 
-            font-size: 1.2rem;
-            letter-spacing: 0.5px;
+            font-size: var(--micro-font-size-small);
+            letter-spacing: 0.25px;
         }
     }
 

--- a/layouts/shortcodes/event-card.html
+++ b/layouts/shortcodes/event-card.html
@@ -111,8 +111,6 @@
     #{{ $id }}.card-host {
         display: block;
         position: relative;
-
-        margin-bottom: 1.5rem;
     }
 
     .card-header {

--- a/layouts/shortcodes/event-card.html
+++ b/layouts/shortcodes/event-card.html
@@ -37,52 +37,74 @@
 </div>
 
 <script type="module">
-    // TODO: Refactor this once we support object annotations
+    const spectrogramTarget = document.getElementById("{{ $id }}-spectrogram");
+    const annotationTarget = document.getElementById("{{ $id }}-annotations");
+
+    // TODO: Refactor this function once we support object annotations
     // see: https://github.com/ecoacoustics/web-components/issues/501
-    function createAnnotation(audioEvent, label, contextPadding, annotateOutlet) {
+    function createAnnotation(audioEvent, label, contextPaddingStart) {
         const eventDuration = audioEvent.end_time_seconds - audioEvent.start_time_seconds;
 
         const annotationElement = document.createElement("oe-annotation");
-        annotationElement.setAttribute("start-time", contextPadding);
-        annotationElement.setAttribute("end-time", eventDuration + contextPadding);
+        annotationElement.setAttribute("start-time", contextPaddingStart);
+        annotationElement.setAttribute("end-time", eventDuration + contextPaddingStart);
         annotationElement.setAttribute("low-frequency", audioEvent.low_frequency_hertz);
         annotationElement.setAttribute("high-frequency", audioEvent.high_frequency_hertz);
         annotationElement.setAttribute("tags", label);
 
-        annotateOutlet.appendChild(annotationElement);
+        annotationTarget.appendChild(annotationElement);
     }
 
     const api = await workbenchApi();
-
-    const targetSpectrogram = document.getElementById("{{ $id }}-spectrogram");
-    const targetAnnotations = document.getElementById("{{ $id }}-annotations");
 
     const audioRecordingId = {{ $audio_recording_id }};
     const audioEventId = {{ $audio_event_id }};
     const label = "{{ $label }}";
 
-    const audioEvent = await api.getAudioEvent(audioRecordingId, audioEventId);
+    // We use promise.all here so that we can fetch both the audio event and the
+    // audio recording in parallel.
+    // We also use .all instead of .allSettled so that if one of the requests
+    // fails, we can immediately show an error to the user instead of waiting
+    // for all requests to finish.
+    const [audioRecording, audioEvent] = await Promise.all([
+        api.getAudioRecording(audioRecordingId),
+        api.getAudioEvent(audioRecordingId, audioEventId),
+    ]);
 
     const eventDuration = audioEvent.end_time_seconds - audioEvent.start_time_seconds;
+    const audioRecordingDuration = audioRecording.duration_seconds;
 
     // A padding around the event in seconds to give the user some context
-    // If the event is very short (e.g. less than 4 seconds), we we want to use
-    // some smaller padding so that the event is the center of attention.
-    // But if the event is longer than 4 seconds, we just pad by a fixed 2
-    // seconds.
+    // If the event is very short (e.g. less than 8 seconds), we we want to use
+    // some smaller context padding so that the event is the center of the users
+    // attention.
+    // But if we have a longer event, we want to fix the context padding to a
+    // maximum of 2 seconds in order to conserve visual space.
+    //
+    // Additionally, we clamp to the start and end of the recording so that we
+    // don't try to fetch audio that is outside the bounds of the recording.
     const contextPadding = Math.min(2, eventDuration / 4);
     const contextStartTime = Math.max(audioEvent.start_time_seconds - contextPadding, 0);
-    const contextEndTime = audioEvent.end_time_seconds + contextPadding;
+    const contextEndTime = Math.min(audioEvent.end_time_seconds + contextPadding, audioRecordingDuration);
 
+    // How much padding we added to the start of the event. Because this can be
+    // clamped to the start of the recording, we need to calculate this after
+    // we calculate the context start time.
+    const contextPaddingStart = audioEvent.start_time_seconds - contextStartTime;
 
-    const contextEvent = {
+    const eventWithContext = {
         ...audioEvent,
         start_time_seconds: contextStartTime,
         end_time_seconds: contextEndTime,
     };
-    targetSpectrogram.src = api.audioEventUrl(contextEvent);
+    spectrogramTarget.src = api.audioEventUrl(eventWithContext);
 
-    createAnnotation(audioEvent, label, contextPadding, targetAnnotations);
+    // Draws a bounding box around the original event.
+    // We need the contextPaddingStart because we need to know how many seconds
+    // from the start of the spectrogram the event starts at.
+    // We cannot use the contextPadding in case the context start time was
+    // clamped to the start of the recording.
+    createAnnotation(audioEvent, label, contextPaddingStart);
 </script>
 
 <style>
@@ -96,8 +118,11 @@
     .card-header {
         display: flex;
         justify-content: space-between;
+        align-items: center;
 
         .event-label {
+            margin: 0;
+
             font-size: 1.2rem;
             letter-spacing: 0.5px;
         }

--- a/layouts/shortcodes/event-card.html
+++ b/layouts/shortcodes/event-card.html
@@ -1,30 +1,108 @@
-{{ $id := printf "spectrogram-card-%03d" $.Ordinal }}
+{{ $audio_recording_id := .Get "audioRecordingId" }}
+{{ $audio_event_id := .Get "audioEventId" }}
+{{ $label := .Get "label" }}
 
-{{ $audio_event_url := .Get "audioEventUrl" }}
+{{- if not $audio_recording_id -}}
+    {{ errorf "Missing audioRecordingId for event card with label %s" $label }}
+{{- end -}}
 
-<div>
+{{- if not $audio_event_id -}}
+    {{ errorf "Missing audioEventId for event card with label %s" $label }}
+{{- end -}}
+
+{{ $id := printf "event-card-%03d" $.Ordinal }}
+
+<div id="{{ $id }}" class="card-host">
     <sl-card class="spectrogram-card">
-        <h3 class="card-heading">{{ .Get "title" }}</h3>
-        <p class="progress-text">{{ .Get "description" }}</p>
+        <div class="card-header" slot="header">
+            <h3 class="event-label">{{ $label }}</h3>
+            <oe-media-controls for="{{ $id }}-spectrogram"></oe-media-controls>
+        </div>
 
-        <oe-annotate>
-            <oe-indicator>
-                <oe-spectrogram id="{{ $id }}"></oe-spectrogram>
-            </oe-indicator>
-        </oe-annotate>
-        <oe-media-controls for="{{ $id }}"></oe-media-controls>
+        <div class="card-body">
+            <oe-annotate id="{{ $id }}-annotations">
+                <oe-axes>
+                    <oe-indicator>
+                        <oe-spectrogram
+                            id="{{ $id }}-spectrogram"
+                            class="event-spectrogram"
+                        ></oe-spectrogram>
+                    </oe-indicator>
+                </oe-axes>
+            </oe-annotate>
+        </div>
 
         {{ .Inner }}
     </sl-card>
 </div>
 
 <script type="module">
-    const spectrogramElement = document.getElementById("{{ $id }}");
+    // TODO: Refactor this once we support object annotations
+    // see: https://github.com/ecoacoustics/web-components/issues/501
+    function createAnnotation(audioEvent, label, contextPadding, annotateOutlet) {
+        const eventDuration = audioEvent.end_time_seconds - audioEvent.start_time_seconds;
 
-    const audioEventUrl = "{{ $audio_event_url }}";
+        const annotationElement = document.createElement("oe-annotation");
+        annotationElement.setAttribute("start-time", contextPadding);
+        annotationElement.setAttribute("end-time", eventDuration + contextPadding);
+        annotationElement.setAttribute("low-frequency", audioEvent.low_frequency_hertz);
+        annotationElement.setAttribute("high-frequency", audioEvent.high_frequency_hertz);
+        annotationElement.setAttribute("tags", label);
+
+        annotateOutlet.appendChild(annotationElement);
+    }
+
+    const api = await workbenchApi();
+
+    const targetSpectrogram = document.getElementById("{{ $id }}-spectrogram");
+    const targetAnnotations = document.getElementById("{{ $id }}-annotations");
+
+    const audioRecordingId = {{ $audio_recording_id }};
+    const audioEventId = {{ $audio_event_id }};
+    const label = "{{ $label }}";
+
+    const audioEvent = await api.getAudioEvent(audioRecordingId, audioEventId);
+
+    const eventDuration = audioEvent.end_time_seconds - audioEvent.start_time_seconds;
+
+    // A padding around the event in seconds to give the user some context
+    // If the event is very short (e.g. less than 4 seconds), we we want to use
+    // some smaller padding so that the event is the center of attention.
+    // But if the event is longer than 4 seconds, we just pad by a fixed 2
+    // seconds.
+    const contextPadding = Math.min(2, eventDuration / 4);
+    const contextStartTime = Math.max(audioEvent.start_time_seconds - contextPadding, 0);
+    const contextEndTime = audioEvent.end_time_seconds + contextPadding;
+
+
+    const contextEvent = {
+        ...audioEvent,
+        start_time_seconds: contextStartTime,
+        end_time_seconds: contextEndTime,
+    };
+    targetSpectrogram.src = api.audioEventUrl(contextEvent);
+
+    createAnnotation(audioEvent, label, contextPadding, targetAnnotations);
 </script>
 
 <style>
+    #{{ $id }}.card-host {
+        display: block;
+        position: relative;
+
+        margin-bottom: 1.5rem;
+    }
+
+    .card-header {
+        display: flex;
+        justify-content: space-between;
+
+        .event-label {
+            font-size: 1.2rem;
+            letter-spacing: 0.5px;
+        }
+    }
+
     .spectrogram-card {
         display: block;
     }

--- a/layouts/shortcodes/event-card.html
+++ b/layouts/shortcodes/event-card.html
@@ -64,23 +64,21 @@
     const audioRecordingDuration = audioRecording.duration_seconds;
 
     // A padding around the event in seconds to give the user some context
-    // If the event is very short (e.g. less than 8 seconds), we we want to use
-    // some smaller context padding so that the event is the center of the users
-    // attention.
-    // But if we have a longer event, we want to fix the context padding to a
-    // maximum of 2 seconds in order to conserve visual space.
-    //
-    // Additionally, we clamp to the start and end of the recording so that we
-    // don't try to fetch audio that is outside the bounds of the recording.
     const minimumEventDurationSeconds = 4;
     const defaultPaddingSeconds = 1;
 
+    // If the recording is less than 4 seconds, we add extra padding so that it
+    // is at least 4 seconds long.
+    // Additionally, we always add a default padding of 1 second so there is
+    // always some context around the event.
     const contextPaddingSeconds = eventDuration < minimumEventDurationSeconds
-        ? eventDuration / 2
+        ? ((minimumEventDurationSeconds - eventDuration) / 2) + defaultPaddingSeconds
         : defaultPaddingSeconds;
 
-    const contextStartTime = Math.max(audioEvent.start_time_seconds - contextPaddingSeconds, 0);
-    const contextEndTime = Math.min(audioEvent.end_time_seconds + contextPaddingSeconds, audioRecordingDuration);
+    // We clamp to the start and end of the recording so that we don't try to
+    // fetch audio that is outside the bounds of the recording.
+    const contextStartTime = Math.max(audioEvent.start_time_seconds - contextPaddingSeconds, 0).toFixed(2);
+    const contextEndTime = Math.min(audioEvent.end_time_seconds + contextPaddingSeconds, audioRecordingDuration).toFixed(2);
 
     // How much padding we added to the start of the event. Because this can be
     // clamped to the start of the recording, we need to calculate this after

--- a/layouts/shortcodes/section/project-progress.html
+++ b/layouts/shortcodes/section/project-progress.html
@@ -38,14 +38,14 @@
             */
             & > .progress-percentage {
                 display: block;
-                min-height: 144px;
+                min-height: 9rem;
 
                 font-size: 6rem;
             }
 
             & > .progress-text {
                 display: block;
-                min-height: 24px;
+                min-height: 1.5em;
                 margin-bottom: var(--micro-padding-small);
 
                 font-weight: 600;

--- a/layouts/shortcodes/section/project-progress.html
+++ b/layouts/shortcodes/section/project-progress.html
@@ -38,14 +38,14 @@
             */
             & > .progress-percentage {
                 display: block;
-                min-height: 6rem;
+                min-height: 144px;
 
                 font-size: 6rem;
             }
 
             & > .progress-text {
                 display: block;
-                min-height: 1em;
+                min-height: 24px;
                 margin-bottom: var(--micro-padding-small);
 
                 font-weight: 600;

--- a/microsite.code-workspace
+++ b/microsite.code-workspace
@@ -67,7 +67,7 @@
             "tamasfe.even-better-toml",
             "dbaeumer.vscode-eslint",
             "stylelint.vscode-stylelint",
-            "aaron-bond.better-comments",
+            "aaron-bond.better-comments"
         ]
     }
 }


### PR DESCRIPTION
## Changes

- Adds an `event-card` shortcode that you can use to embed an ecosounds/A2O event in your page. The event cards are made to look consistent with the cards in the verification grid.
- Adds "unsure" button to verification grid
- Bumps web component version
- Increases 1x1 grid width from `800px` to `896px`. This was needed to stop control wrapping on the 1x1 grid. Remember that the controls are now always centered, meaning that the left control group was able to fit because it's take space from the right control group. Now that the right control group always has allocated space, we have to increase the 1x1 grid size by `96px` (6rem).
- Refactor `--nav-color` into its own theming variable (with the default value unchanged). As we saw with the previous microsite, we sometimes want to change the footer/header color without changing the panel colors.
- Adds `workbenchApi` method to fetch an `audioEvent` model
- Refactor adding `?user_token` parameter into its own private `workbenchApi` method
- Adds API functionality to delete a verification

### Bug fixes

- Fixes browser incompatibilities with how `:has(::content)` works on different browsers. We now use `:not(:empty)`
- Removes layout shift on project-progress card
- Fix code-workspace using both 4 tab width and 2 tab width (set explicitly to 4)

## Code Examples

```mustache
{{< event-card audioRecordingId="352803" audioEventId="269965" label="Plains Wander (female)" >}}
{{< /event-card >}}
```

Fixes: #88

## Visual Changes

<img width="1920" height="1594" alt="image" src="https://github.com/user-attachments/assets/2a34cab2-14f1-41a0-9200-376dc0f928dd" />

_Example of new audio event cards on the verification page_