### PR TITLE
Bump web components to version 6

### DIFF
--- a/layouts/_default/verify.html
+++ b/layouts/_default/verify.html
@@ -32,7 +32,7 @@
 
     <script
         type="module"
-        src="https://cdn.jsdelivr.net/npm/@ecoacoustics/web-components@5/dist/components.js"
+        src="https://cdn.jsdelivr.net/npm/@ecoacoustics/web-components@6/dist/components.js"
     ></script>
 
     {{- with resources.Get "js/bootstrapVerificationGrid.js" }}

--- a/layouts/_default/verify.html
+++ b/layouts/_default/verify.html
@@ -32,7 +32,7 @@
 
     <script
         type="module"
-        src="https://cdn.jsdelivr.net/npm/@ecoacoustics/web-components@6/dist/components.js"
+        src="https://cdn.jsdelivr.net/npm/@ecoacoustics/web-components@6.0.1/dist/components.js"
     ></script>
 
     {{- with resources.Get "js/bootstrapVerificationGrid.js" }}


### PR DESCRIPTION
## Changes

- Bumps web components to version 6
- Verification grid now supports slotted templates
- Fix overlapping content when browser window was < 300px in height
- Improved performance during highlight box selection

<img width="962" height="877" alt="image" src="https://github.com/user-attachments/assets/f7148ac7-5487-497a-a841-abce1c2fdbc9" />

I did further testing outside of this video. However, this video is a short demonstration that making and updating decisions is working correctly.