### PR TITLE
Fix deployment.md typos

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -15,7 +15,6 @@ Most of the steps described can be found in the hugo
 3. Install [git lfs](https://git-lfs.com/) hooks into the repository by running `git lfs install`
 4. Add the microsite template as a theme
     - `git submodule add https://github.com/ecoacoustics/microsite-template.git themes/microsite-template`
-    - `echo "theme: "microsite-template" >> hugo.yaml`
 5. Initialize the websites content from the microsite template
     - `cp -r ./themes/microsite-template/content/* ./content/`
     - `cp ./themes/microsite-template/netlify.toml ./netlify.toml`

--- a/hugo.example.yaml
+++ b/hugo.example.yaml
@@ -5,10 +5,10 @@ services:
   # googleAnalytics:
   #   id: G-MEASUREMENT_ID
 menus:
-#   main:
-#     - name: Credits
-#       pageRef: https://ecosounds.org/about/credits
-#       weight: 10
+  # main:
+  #   - name: Credits
+  #     pageRef: https://ecosounds.org/about/credits
+  #     weight: 10
 params:
   apiHost: https://api.staging.ecosounds.org
   workbenchHost: https://staging.ecosounds.org

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -24,13 +24,13 @@ services:
   # googleAnalytics:
   #   id: G-MEASUREMENT_ID
 menus:
-#   main:
-#     - name: Credits
-#       pageRef: https://ecosounds.org/about/credits
-#       weight: 10
-#   footer:
-#     - name: Ecosounds Project
-#       pageRef: https://www.ecosounds.org/projects/1131
+  # main:
+  #   - name: Credits
+  #     pageRef: https://ecosounds.org/about/credits
+  #     weight: 10
+  # footer:
+  #   - name: Ecosounds Project
+  #     pageRef: https://www.ecosounds.org/projects/1131
 params:
   apiHost: https://api.staging.ecosounds.org
   workbenchHost: https://staging.ecosounds.org


### PR DESCRIPTION
Removes un-needed `echo "theme: "microsite-template" >> hugo.yaml` instruction that gets overwritten in the following step