### PR TITLE
Add oe-header selector

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,3 +1,3 @@
-<header>
+<header class="oe-header">
     {{ partial "navigation.html" (dict "menuID" "main" "page" .) }}
 </header>


### PR DESCRIPTION
This allows you to directly target the header element in a nice way, meaning that you can overwrite styles such as making the navbar fixed / overlay content.

Fixes: #101