### PR TITLE
Add optional "class" attribute to card shortcode

### DIFF
--- a/layouts/shortcodes/card.html
+++ b/layouts/shortcodes/card.html
@@ -1,4 +1,4 @@
-<sl-card>
+<sl-card class='{{ .Get "class" }}'>
   {{ with .Get "image"  -}}
   {{- $image := resources.Get . -}}
     <img


### PR DESCRIPTION
You can now use a `class` attribute on the `{{< card >}}` shortcode to add a class to the `sl-card` root element