### PR TITLE
Lazy load images

### DIFF
--- a/layouts/shortcodes/card.html
+++ b/layouts/shortcodes/card.html
@@ -5,6 +5,7 @@
       slot="image"
       src="{{ $image.RelPermalink }}"
       alt='{{ $.Get "alt" }}'
+      loading="lazy"
     />
   {{- end -}}
   {{ .Inner }}

--- a/layouts/shortcodes/section/image-column.html
+++ b/layouts/shortcodes/section/image-column.html
@@ -6,6 +6,7 @@
       src="{{ $image.RelPermalink }}"
       {{ end }}
       alt='{{ .Get "alt" }}'
+      loading="lazy"
     >
     <figcaption class="oe-image-caption">{{ .Get "caption" }}</figcaption>
   </figure>

--- a/layouts/shortcodes/sponsors.html
+++ b/layouts/shortcodes/sponsors.html
@@ -15,6 +15,7 @@
                 <img
                     src="{{ .RelPermalink }}"
                     alt="OpenEcoacoustics Logo"
+                    loading="lazy"
                 />
                 {{- end -}}
             </a>
@@ -29,6 +30,7 @@
                 <img
                     src="{{ .RelPermalink }}"
                     alt="ARDC Logo"
+                    loading="lazy"
                 />
                 {{- end -}}
             </a>
@@ -43,6 +45,7 @@
                 <img
                     src="{{ .RelPermalink }}"
                     alt="Australian Government & NCRIS Logo"
+                    loading="lazy"
                 />
                 {{- end -}}
             </a>


### PR DESCRIPTION
Because websites are very content heavy, they can become slow with a lot of images.

By lazy loading images, our initial page load speeds should significantly improve.

Fixes: #128