### PR TITLE
Updated progress counter to show 0% if there are no events to verify.

### DIFF
--- a/layouts/shortcodes/section/project-progress.html
+++ b/layouts/shortcodes/section/project-progress.html
@@ -111,7 +111,7 @@
 
         // I floor the number so that when we approach 100% verification, users
         // don't see a 100% verified state and stop verifying.
-        const progressPercentage = Math.floor(100 * (verified / totalCount));
+        const progressPercentage = totalCount === 0 ? 0 : Math.floor(100 * (verified / totalCount));
         const roundedPercentage = progressPercentage.toFixed(0);
         const percentageMessage = `${roundedPercentage}%`;
 


### PR DESCRIPTION
In active projects this shouldn't be the case, but it might happen early in a project during dev. Showing 0% is preferable to NaN

 fixes #145